### PR TITLE
Fix PHP 8.4 warnings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,9 @@ php8.4 vendor/bin/phpunit --configuration phpunit.xml.dist # or php8.3 if 8.4 no
 php7.4 vendor/bin/phpunit --configuration phpunit.xml.dist
 ```
 
+Rules of design:
+- The language of the project is English, so all comments, branch names, and documentation are written in English
+
 Package Notes
 -------------
 - The project uses PHPUnit 9.x and requires the `dom`, `json`, `libxml`, `mbstring`, `tokenizer`, and `xmlwriter` extensions.

--- a/src/Decorators/PhraseTranslatorDecorator.php
+++ b/src/Decorators/PhraseTranslatorDecorator.php
@@ -19,8 +19,8 @@ class PhraseTranslatorDecorator implements TranslatorInterface
 
     public function __construct(
         TranslatorInterface $translator,
-        OriginalPhraseDecoratorManager $originalDecoratorManager = null,
-        TranslatePhraseDecoratorManager $translateDecoratorManager = null
+        ?OriginalPhraseDecoratorManager $originalDecoratorManager = null,
+        ?TranslatePhraseDecoratorManager $translateDecoratorManager = null
     )
     {
         $this->translator = $translator;
@@ -66,13 +66,13 @@ class PhraseTranslatorDecorator implements TranslatorInterface
         $this->translator->saveTranslate($originalLanguageAlias, $translationLanguageAlias, $original, $translate);
     }
 
-    public function delete(string $originalLanguageAlias, string $original, string $translationLanguageAlias = null): void
+    public function delete(string $originalLanguageAlias, string $original, ?string $translationLanguageAlias = null): void
     {
         $original = $this->originalDecoratorManager->decorate($original);
         $this->translator->delete($originalLanguageAlias, $original, $translationLanguageAlias);
     }
 
-    public function getSource(string $originalLanguageAlias,string $translationLanguageAlias = null): SourceInterface
+    public function getSource(string $originalLanguageAlias, ?string $translationLanguageAlias = null): SourceInterface
     {
         return $this->translator->getSource($originalLanguageAlias, $translationLanguageAlias);
     }

--- a/src/PlainTranslator/PlainTranslator.php
+++ b/src/PlainTranslator/PlainTranslator.php
@@ -68,7 +68,7 @@ class PlainTranslator implements PlainTranslatorInterface
         return $this->translator->translate($this->originalLanguageAlias, $this->translationLanguageAlias, $phrase, $withTranslationFallback);
     }
 
-    public function saveTranslate(string $original,string $translate, string $translationLanguageAlias = null): void
+    public function saveTranslate(string $original, string $translate, ?string $translationLanguageAlias = null): void
     {
         $translationLanguageAlias = $translationLanguageAlias ?: $this->translationLanguageAlias;
 

--- a/src/Source/SourceReaderInterface.php
+++ b/src/Source/SourceReaderInterface.php
@@ -45,5 +45,5 @@ interface SourceReaderInterface
      * @param int|null $limit
      * @return OriginalPhraseCollection
      */
-    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, int $limit = null): OriginalPhraseCollection;
+    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, ?int $limit = null): OriginalPhraseCollection;
 }

--- a/src/Source/Sources/EventDriven/EventDrivenSource.php
+++ b/src/Source/Sources/EventDriven/EventDrivenSource.php
@@ -134,7 +134,7 @@ class EventDrivenSource implements SourceInterface
         return $this->innerWriter->getExistOriginals($phrases);
     }
 
-    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, int $limit = null): OriginalPhraseCollection
+    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, ?int $limit = null): OriginalPhraseCollection
     {
         return $this->innerWriter->getOriginalsWithoutTranslate($translationLanguageAlias, $offset, $limit);
     }

--- a/src/Source/Sources/FileSources/CsvSource/CsvFileSource.php
+++ b/src/Source/Sources/FileSources/CsvSource/CsvFileSource.php
@@ -119,7 +119,7 @@ class CsvFileSource extends FileSourceAbstract
 
         foreach ($translatesData as $original => $translate) {
             $id = $this->getNextIncrementId();
-            fputcsv($fileResource, [$original, $translate, $id], $this->delimiter);
+            fputcsv($fileResource, [$original, $translate, $id], $this->delimiter, '"', '\\');
         }
 
         fclose($fileResource);
@@ -257,7 +257,7 @@ class CsvFileSource extends FileSourceAbstract
      * @throws FileReadPermissionsException
      * @throws UnsupportedLanguageAliasException
      */
-    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, int $limit = null): OriginalPhraseCollection
+    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, ?int $limit = null): OriginalPhraseCollection
     {
         $this->preloadTranslates($translationLanguageAlias);
 
@@ -313,7 +313,7 @@ class CsvFileSource extends FileSourceAbstract
             }
 
             $fileResource = fopen($languageFile, 'rb');
-            while (($data = fgetcsv($fileResource, 0, $this->delimiter)) !== false) {
+            while (($data = fgetcsv($fileResource, 0, $this->delimiter, '"', '\\')) !== false) {
                 yield $data;
             }
             fclose($fileResource);

--- a/src/Source/Sources/MySqlSource/MySqlSource.php
+++ b/src/Source/Sources/MySqlSource/MySqlSource.php
@@ -398,7 +398,7 @@ class MySqlSource implements SourceInterface
         return new MySqlSourceInstaller($this->pdo, $this->originalTableName, $this->translateTableName);
     }
 
-    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, int $limit = null): OriginalPhraseCollection
+    public function getOriginalsWithoutTranslate(string $translationLanguageAlias, int $offset = 0, ?int $limit = null): OriginalPhraseCollection
     {
         $originalsWithoutTranslationCollection = new OriginalPhraseCollection($this->originalLanguageAlias);
 

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -33,7 +33,7 @@ class Translator implements TranslatorInterface
         return $this->sourceCollection;
     }
 
-    public function getSource(string $originalLanguageAlias,string $translationLanguageAlias = null): SourceInterface
+    public function getSource(string $originalLanguageAlias, ?string $translationLanguageAlias = null): SourceInterface
     {
         $source = $this->sourceCollection->getSource($originalLanguageAlias, $translationLanguageAlias);
         if (!$source) {
@@ -136,7 +136,7 @@ class Translator implements TranslatorInterface
     public function delete(
         string $originalLanguageAlias,
         string $original,
-        string $translationLanguageAlias = null
+        ?string $translationLanguageAlias = null
     ): void
     {
         $this->getSource($originalLanguageAlias, $translationLanguageAlias)->delete($original);

--- a/src/TranslatorInterface.php
+++ b/src/TranslatorInterface.php
@@ -9,7 +9,7 @@ interface TranslatorInterface
 {
     public function getSource(
         string $originalLanguageAlias,
-        string $translationLanguageAlias = null
+        ?string $translationLanguageAlias = null
     ): ?SourceInterface;
 
     /**
@@ -44,6 +44,6 @@ interface TranslatorInterface
     public function delete(
         string $originalLanguageAlias,
         string $original,
-        string $translationLanguageAlias = null
+        ?string $translationLanguageAlias = null
     ): void;
 }


### PR DESCRIPTION
## Summary
- update nullable parameter types
- add escape parameter for CSV functions

## Testing
- `php8.4 vendor/bin/phpunit --configuration phpunit.xml.dist`
- `php7.4 vendor/bin/phpunit --configuration phpunit.xml.dist`


------
https://chatgpt.com/codex/tasks/task_e_684e76009c44832e939af96bb239fb62